### PR TITLE
[figma]:update to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "23mofang-icons",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Automation workflow with Figma",
   "main": "bundle/index.common.js",
   "files": [


### PR DESCRIPTION
彩色图标的再次尝试