### PR TITLE
[figma]:update to 0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "23mofang-icons",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "description": "Automation workflow with Figma",
   "main": "bundle/index.common.js",
   "files": [


### PR DESCRIPTION
1. 统一显示尺寸为 64；
2. 删掉了一些图标；
3. 新增扁平彩色图标和质感细腻彩色图标；