### PR TITLE
[figma]:update to 0.1.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "23mofang-icons",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Automation workflow with Figma",
   "main": "bundle/index.common.js",
   "files": [


### PR DESCRIPTION
1. 给彩色图标，统一加了「color_」前缀；