### PR TITLE
[figma]:update to 0.1.59

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "23mofang-icons",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "description": "Automation workflow with Figma",
   "main": "bundle/index.common.js",
   "files": [


### PR DESCRIPTION
1. 找到原因了，多了一个空格符号命名的时候；