### PR TITLE
[figma]:update to 0.1.72

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "23mofang-icons",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "description": "Automation workflow with Figma",
   "main": "bundle/index.common.js",
   "files": [


### PR DESCRIPTION
1. 修复彩色社区图标