### PR TITLE
[figma]:update to 0.1.77

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "23mofang-icons",
-  "version": "0.1.76",
+  "version": "0.1.77",
   "description": "Automation workflow with Figma",
   "main": "bundle/index.common.js",
   "files": [


### PR DESCRIPTION
1. 一次尝试3个试试看，能不能修复对勾图标；