### PR TITLE
[figma]:update to 1.17.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "23mofang-icons",
-  "version": "1.17.35",
+  "version": "1.17.36",
   "description": "Automation workflow with Figma",
   "main": "bundle/index.common.js",
   "files": [


### PR DESCRIPTION
1. 修复 20 arrow mini 命名，新增 ic 开头；